### PR TITLE
Feat/get book by ID and CI Pipeline

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: CI Pipeline
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'  
+
+      - name: Install dependencies
+        run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: |
+          source venv/bin/activate
+          pytest

--- a/api/routes/books.py
+++ b/api/routes/books.py
@@ -62,3 +62,10 @@ async def delete_book(book_id: int) -> None:
     db.delete_book(book_id)
     return JSONResponse(status_code=status.HTTP_204_NO_CONTENT, content=None)
 
+@router.get("/{book_id}", response_model=Book, status_code=status.HTTP_200_OK)
+async def get_book_by_id(book_id: int):
+    book = db.books.get(book_id)
+    if not book:
+        return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content={"detail": "Book not found"})
+    return book
+


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.  
- Added GitHub Actions workflow (ci.yml) to automate testing on pull requests.
- Configured the pipeline to run pytest on every PR targeting main.

## Testing  
- Ran `pytest` locally (all tests passed).  
- Verified workflow execution under GitHub Actions > Actions Tab.
- Tested invalid IDs (e.g., `/books/8`) to confirm 404 response.  

## Notes  
- Ensure all tests pass before merging this PR.
- View CI logs under GitHub Actions > Workflows > CI Pipeline.